### PR TITLE
Handle whitespace around comma in array definition.

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -97,7 +97,7 @@ fn test_constraint_item_1() {
 }
 #[test]
 fn test_constraint_item_2() {
-    use crate::{Expr, IntExpr};
+    use crate::{BoolExpr, Expr, IntExpr};
     use winnow::error::ContextError;
     let mut input = "constraint int_lin_eq([-1, 1], [INT01, p], -3);";
     assert_eq!(
@@ -106,9 +106,9 @@ fn test_constraint_item_2() {
             id: "int_lin_eq".to_string(),
             exprs: vec![
                 Expr::ArrayOfInt(vec![IntExpr::Int(-1), IntExpr::Int(1)]),
-                Expr::ArrayOfInt(vec![
-                    IntExpr::VarParIdentifier("INT01".to_string()),
-                    IntExpr::VarParIdentifier("p".to_string())
+                Expr::ArrayOfBool(vec![
+                    BoolExpr::VarParIdentifier("INT01".to_string()),
+                    BoolExpr::VarParIdentifier("p".to_string())
                 ]),
                 Expr::Int(-3)
             ],

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    ascii::multispace1,
+    ascii::{multispace0, multispace1},
     combinator::{alt, delimited, opt, preceded, repeat, separated},
     error::{FromExternalError, ParserError},
     token::{take_till, take_while},
@@ -762,10 +762,17 @@ fn array_of_bool_expr_literal<'a, E: ParserError<&'a str>>(
 ) -> PResult<Vec<BoolExpr>, E> {
     '['.parse_next(input)?;
     space_or_comment0(input)?;
-    let v = separated(0.., bool_expr, ',').parse_next(input)?;
+    let v = separated(0.., bool_expr, array_separator).parse_next(input)?;
     space_or_comment0(input)?;
     ']'.parse_next(input)?;
     Ok(v)
+}
+
+fn array_separator<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> PResult<(), E> {
+    multispace0(input)?;
+    ",".parse_next(input)?;
+    multispace0(input)?;
+    Ok(())
 }
 
 pub fn array_of_bool_literal<'a, E: ParserError<&'a str>>(

--- a/src/variables/declarations.rs
+++ b/src/variables/declarations.rs
@@ -263,6 +263,29 @@ fn test_var_decl_item_5() {
         })
     );
 }
+#[test]
+fn test_var_decl_item_6() {
+    use crate::{AnnExpr, Annotation, Expr, IntExpr, SetExpr, SetLiteralExpr};
+    use winnow::error::ContextError;
+    let mut input = "array [1..2] of var bool: bools:: output_array([1..2]) = [x1, x2];";
+    assert_eq!(
+        var_decl_item::<ContextError>(&mut input),
+        Ok(VarDeclItem::ArrayOfBool {
+            ix: IndexSet(2),
+            id: "bools".to_string(),
+            annos: vec![Annotation {
+                id: "output_array".to_string(),
+                expressions: vec![AnnExpr::Expr(Expr::ArrayOfSet(vec![SetExpr::Set(
+                    SetLiteralExpr::IntInRange(IntExpr::Int(1), IntExpr::Int(2))
+                )]))]
+            }],
+            array_expr: Some(ArrayOfBoolExpr::Array(vec![
+                BoolExpr::VarParIdentifier("x1".to_owned()),
+                BoolExpr::VarParIdentifier("x2".to_owned())
+            ]))
+        })
+    );
+}
 
 fn vdi_var<'a, E>(input: &mut &'a str) -> PResult<VarDeclItem, E>
 where


### PR DESCRIPTION
Fix for issue #38.

The array `[x1, x2]` and `[x1,x2]` (note the whitespace) should be the same. However, the former caused the parser to fail. The fix is to parse whitespace preceding and succeeding the comma.

A side-effect is that in one existing test-case, the type is now parsed as an ArrayOfBool instead of ArrayOfInt. The array is an array of identifiers, so the parser does not identify the difference, and since it attempts ArrayOfBool first, that is what it finds.

One thing that is not clear to me, is why this bug does not show up for `ArrayOfInt`. The additional whitespace is being parsed for the integer case, which it did not do in the boolean case.